### PR TITLE
Camel case variable in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Usage
 -----
 
 ```
-var isvg = require('react-inlinesvg');
+var Isvg = require('react-inlinesvg');
 
-<isvg src="/path/to/myfile.svg">
+<Isvg src="/path/to/myfile.svg">
   Here's some optional content for browsers that don't support XHR or inline
   SVGs. You can use other React components here too. Here, I'll show you.
   <img src="/path/to/myfile.png" />
-</isvg>
+</Isvg>
 ```
 
 


### PR DESCRIPTION
Example did not work, but capitalizing the initial character fixed that problem.

Using React 0.13.1.
